### PR TITLE
Make Dockerfile generic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,23 +9,22 @@ RUN apt-get update && \
 
 WORKDIR /app
 
-# Upgrade pip
-RUN pip install --upgrade pip
-
 # First copy requirements.txt so we can take advantage of docker
 # caching.
 COPY requirements.txt /app/requirements.txt
 
 COPY . /app
 
+RUN pip install --upgrade pip
 RUN pip install --no-cache-dir -r requirements.txt
 
 # Running the TAAR job requires setting up AWS S3 credentials as well
 # as a rundate for the job itself.
 
-ENV AWS_ACCESS_KEY_ID=""
-ENV AWS_SECRET_ACCESS_KEY=""
-ENV AWS_DEFAULT_REGION=""
-ENV PROC_DATE=""
+ENV PYTHONUNBUFFERED=1 \
+    # AWS_ACCESS_KEY_ID= \
+    # AWS_SECRET_ACCESS_KEY= \
+    # AWS_DEFAULT_REGION= \
+    # PROC_DATE= \
 
-ENTRYPOINT /usr/local/bin/python -m taar_etl.taar_amodump --date=${PROC_DATE}
+ENTRYPOINT ["/usr/local/bin/python"]


### PR DESCRIPTION
Moving pip upgrade closer to the install. Entrypoint should be generic, and we can configure the env vars, python script and arguments when we define the GKE Pod.