### PR TITLE
Add profiles deletion job

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ build:
 setup_conda:
 	# Install all dependencies and setup repo in dev mode
 	conda env create -f environment.yml
-	#python setup.py develop
+	python setup.py develop
 
 shell:
 	docker run --rm -it mozilla/taar_amodump:latest /bin/bash
@@ -35,6 +35,6 @@ test_delete:
 		--bigtable-table-id=test_table \
 		--bigtable-instance-id=taar-profile \
 		--delete-opt-out-days 28 \
-		--dataflow-workers 2 \
 		--avro-gcs-bucket taar_profile_dump \
+		--sample-rate=1.0 \
 		--bigtable-delete-opt-out

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ build:
 setup_conda:
 	# Install all dependencies and setup repo in dev mode
 	conda env create -f environment.yml
-	python setup.py develop
+	#python setup.py develop
 
 shell:
 	docker run --rm -it mozilla/taar_amodump:latest /bin/bash
@@ -21,3 +21,20 @@ tag_gcr_io:
 
 push_gcr_io:
 	docker push ${TAG_BASE}:${TAG_REV}
+
+
+test_delete:
+	docker run \
+		-v ~/.gcp_creds:/app/creds \
+		-e GOOGLE_APPLICATION_CREDENTIALS=/app/creds/$(GCP_CREDS_NAME) \
+		-e GCLOUD_PROJECT=cfr-personalization-experiment \
+		-it app:build \
+		-m taar_etl.taar_profile_bigtable \
+		--iso-date=20210406 \
+		--gcp-project=cfr-personalization-experiment \
+		--bigtable-table-id=test_table \
+		--bigtable-instance-id=taar-profile \
+		--delete-opt-out-days 28 \
+		--dataflow-workers 2 \
+		--avro-gcs-bucket taar_profile_dump \
+		--bigtable-delete-opt-out

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ taar_lite
 taar_etl.taar_profile_bigtable
 
     This job extracts user profile data from `clients_last_seen` to
-    build a user profile table in Bigtable. This job is split into 3
+    build a user profile table in Bigtable. This job is split into 4
     parts:
 
     1. Filling a BigQuery table with all pertinent data so that we
@@ -131,6 +131,9 @@ taar_etl.taar_profile_bigtable
 
     3. Import of Avro files from Google Cloud Storage into 
        Cloud BigTable.
+
+    4. Delete users that opt-out from telemetry colleciton. 
+       This should be launched separately to be in sync with the main telemetry cleaning job (Shredder).
 
     When this set of tasks is scheduled in Airflow, it is expected
     that the Google Cloud Storage bucket will be cleared at the start of

--- a/README.md
+++ b/README.md
@@ -133,8 +133,7 @@ taar_etl.taar_profile_bigtable
        Cloud BigTable.
 
     4. Delete users that opt-out from telemetry colleciton. 
-       This should be launched separately to be in sync with the main telemetry cleaning job (Shredder).
-
+ 
     When this set of tasks is scheduled in Airflow, it is expected
     that the Google Cloud Storage bucket will be cleared at the start of
     the DAG, and cleared again at the end of DAG to prevent unnecessary

--- a/environment.yml
+++ b/environment.yml
@@ -7,23 +7,33 @@ dependencies:
   - python=3.7.6
   - numpy=1.18.5
   - pip:
-    - apache-beam==2.20.0
+    - apache-beam==2.28.0
+    - appdirs==1.4.4
+    - attrs==20.3.0
     - avro-python3==1.9.2.1
     - black==19.10b0
+    - cachetools==4.2.1
+    - chardet==3.0.4
     - click==7.1.2
+    - crcmod==1.7
+    - dill==0.3.1.1
+    - docopt==0.6.2
     - fastavro==0.21.24
+    - fasteners==0.16
+    - future==0.18.2
     - google-api-core==1.17.0
-    - google-apitools==0.5.28
-    - google-auth==1.14.3
+    - google-apitools==0.5.31
+    - google-auth==1.28.0
     - google-cloud-bigquery==1.24.0
     - google-cloud-bigtable==1.0.0
+    - google-cloud-build==2.0.0
     - google-cloud-core==1.3.0
     - google-cloud-datastore==1.7.4
     - google-cloud-dlp==0.13.0
     - google-cloud-language==1.3.0
     - google-cloud-pubsub==1.0.2
-    - google-cloud-storage==1.29.0
     - google-cloud-spanner==1.16.0
+    - google-cloud-storage==1.29.0
     - google-cloud-videointelligence==1.13.0
     - google-cloud-vision==0.42.0
     - google-resumable-media==0.5.0
@@ -31,14 +41,35 @@ dependencies:
     - grpc-google-iam-v1==0.12.3
     - grpcio==1.29.0
     - grpcio-gcp==0.2.2
+    - hdfs==2.6.0
+    - httplib2==0.17.4
+    - idna==2.10
+    - libcst==0.3.18
     - mock==2.0.0
+    - mypy-extensions==0.4.3
+    - oauth2client==4.1.3
+    - pathspec==0.8.1
+    - pbr==5.5.1
+    - proto-plus==1.18.1
+    - protobuf==3.15.7
+    - pyarrow==2.0.0
+    - pyasn1==0.4.8
+    - pyasn1-modules==0.2.8
+    - pydot==1.4.2
+    - pymongo==3.11.3
+    - pyparsing==2.4.7
     - python-dateutil==2.8.1
     - python-decouple==3.3
     - pytz==2020.1
+    - pyyaml==5.4.1
     - regex==2020.5.14
-    - requests==2.23.0
+    - requests==2.25.1
+    - requests-toolbelt==0.9.1
+    - rsa==4.0
+    - six==1.15.0
     - toml==0.10.1
     - typed-ast==1.4.1
     - typing-extensions==3.7.4.2
+    - typing-inspect==0.6.0
     - urllib3==1.25.9
-    - requests_toolbelt==0.9.1
+

--- a/taar_etl/taar_profile_bigtable.py
+++ b/taar_etl/taar_profile_bigtable.py
@@ -406,7 +406,8 @@ def get_dataflow_options(
     "--dataflow-workers",
     type=int,
     default=20,
-    help="Number of dataflow workers to import Avro into BigTable.",
+    help="Number of dataflow workers to use for stages which use dataflow "
+         "(export to BigTable and profiles deletion).",
 )
 @click.option(
     "--sample-rate",
@@ -453,7 +454,7 @@ def get_dataflow_options(
 @click.option(
     "--bigtable-delete-opt-out",
     "stage",
-    help="Delete data from Bigtable for users sent telemetry deletion requests in the last N days.",
+    help="Delete data from Bigtable for users that sent telemetry deletion requests in the last N days.",
     flag_value="bigtable-delete-opt-out",
     required=True,
 )


### PR DESCRIPTION
It supposed to be called from Airflow DAG after the main telemetry cleaning jobs are completed (shredder) to be in sync with telemetry deletion, otherwise if profiles are deleted from BigTable but not from telemetry they might be repopulated by `taar_weekly` job.

The job was tested locally using a sandbox GCP project.

Bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1651794

Related Airflow PR: https://github.com/mozilla/telemetry-airflow/pull/1281