### PR TITLE
Limit clients deletion request to the specified date

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,10 +29,10 @@ test_delete:
 		-e GCLOUD_PROJECT=moz-fx-data-taar-nonprod-48b6  \
 		-it app:build \
 		-m taar_etl.taar_profile_bigtable \
-		--iso-date=20210406 \
-		--gcp-project=cfr-personalization-experiment \
-		--bigtable-table-id=test_table \
-		--bigtable-instance-id=taar-profile \
+		--iso-date=20210426 \
+		--gcp-project=moz-fx-data-taar-nonprod-48b6 \
+		--bigtable-table-id=taar_profile \
+		--bigtable-instance-id=taar-stage-202006 \
 		--delete-opt-out-days 28 \
 		--avro-gcs-bucket moz-fx-data-taar-nonprod-48b6-stage-etl \
 		--subnetwork regions/us-west1/subnetworks/gke-taar-nonprod-v1 \

--- a/taar_etl/taar_profile_bigtable.py
+++ b/taar_etl/taar_profile_bigtable.py
@@ -198,6 +198,7 @@ class ProfileDataExtraction:
         select distinct client_id
         from `moz-fx-data-shared-prod.telemetry.deletion_request`
         where date(submission_timestamp) >= DATE_SUB(DATE '{self.ISODATE_DASH}', INTERVAL {days} DAY)
+              and date(submission_timestamp) <= '{self.ISODATE_DASH}'
         """
 
         options = get_dataflow_options(


### PR DESCRIPTION
The goal is to not read too much data from Bigquery on backfilling. It shouldn't affect regular execution.